### PR TITLE
Allow specifying storage type for EBS images.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,3 @@
 FEATURES:
 
  * [GH-7] - Removed quotation inside output of `ami_id` as required for Terraform v0.7 (antonbabenko)
-  

--- a/ebs/main.tf
+++ b/ebs/main.tf
@@ -1,9 +1,13 @@
 variable "region" {}
 variable "distribution" {}
 variable "architecture" {
-  default = "amd64"
+    default = "amd64"
 }
 variable "instance_type" {}
+variable "storagetype" {
+    default = "ebs"
+    description = "storage type for EBS volumes. Choose 'ebs', 'ebs-ssd', or 'ebs-io1'"
+}
 
 module "virttype" {
     source = "github.com/terraform-community-modules/tf_aws_virttype"
@@ -15,7 +19,7 @@ module "ami" {
     distribution = "${var.distribution}"
     architecture = "${var.architecture}"
     virttype = "${module.virttype.prefer_hvm}"
-    storagetype = "ebs"
+    storagetype = "${var.storagetype}"
     source = "../"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,5 @@ variable "storagetype" {
 }
 
 output "ami_id" {
-    value = "${lookup(var.all_amis, format("%s-%s-%s-%s-%s", var.region, var.distribution, var.architecture, var.virttype, var.storagetype))}"
+    value = "${lookup(var.all_amis, format("%s-%s-%s-%s-%s", var.region, var.distribution, var.architecture, var.virttype, var.storagetype), "ERROR: no AMI matching '${format("%s-%s-%s-%s-%s", var.region, var.distribution, var.architecture, var.virttype, var.storagetype)}' found")}"
 }
-


### PR DESCRIPTION
I was trying to provision a `t2.micro` in `us-west-2` and was getting all sorts of bizarro errors from TF.
It turns out there are two problems:
- `lookup()` does not return an error when it fails to find a value in the map.
- There are no `ebs` types for `t2.micro` in `us-west-2`.

This PR adds a default ugly message to the `lookup()`, and lets the user pick a different storage type for EBS backed instances. Kind of nasty, since the EBS sub-module is supposed to do the magic for you, but I can't think of a way to infer the desires of the people using this module.

Also, remove trailing whitespace. 
